### PR TITLE
fix: getOutOfList editor.js update event not emitted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -577,7 +577,9 @@ export default class NestedList {
    * @returns {void}
    */
   getOutOfList() {
-    this.currentItem.remove();
+    setTimeout(function() {
+      this.currentItem.remove();
+    }, 0)
 
     this.api.blocks.insert();
     this.api.caret.setToBlock(this.api.blocks.getCurrentBlockIndex());


### PR DESCRIPTION
When usage relies on editor.js events (block added/remove/updated), the behavior when user presses "Enter" on last empty item does not trigger editor.js block updated event. As a result, the last item is removed visually, but no change can be detected externally.
Delaying remove current item call solves the issue. The event is emitted and behavior does not change.