### PR TITLE
Prevent duplicated event in Chinese, Japanese and Korean languages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -460,6 +460,13 @@ export default class NestedList {
     event.preventDefault();
 
     /**
+     * Prevent duplicated event in Chinese, Japanese and Korean languages
+     */
+    if (event.isComposing) {
+      return;
+    }
+
+    /**
      * On Enter in the last empty item, get out of list
      */
     const isEmpty = this.getItemContent(currentItem).trim().length === 0;


### PR DESCRIPTION
Currently with CJK languages, keyboard event is duplicated on 'Enter' click.

This PR prevents CJK users from unexpected character duplication.

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing