### PR TITLE
Support multiple pasting formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/nested-list",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "keywords": [
     "codex editor",
     "nested-list",

--- a/src/index.js
+++ b/src/index.js
@@ -247,11 +247,18 @@ export default class NestedList {
     const getPastedItems = (parent) => {
       let responseData = [];
       // get first level li elements.
-      const children = Array.from(parent.querySelectorAll(`:scope > li`));
+      const children = Array.from(parent.querySelectorAll(`:scope > li, :scope > ${tagToSearch}`));
 
       children.map((child) => {
-        const listItem = getListItem(child);
-        responseData = responseData.concat(listItem);
+        if (child.tagName === tag) {
+          const nestedListContainers = getNestedListContainers(parent);
+          const previousListItem = responseData.pop();
+          previousListItem.items = nestedListContainers;
+          responseData = responseData.concat(previousListItem);
+        } else {
+          const listItem = getListItem(child);
+          responseData = responseData.concat(listItem);
+        }
       });
 
       return responseData;

--- a/src/index.js
+++ b/src/index.js
@@ -227,25 +227,54 @@ export default class NestedList {
       items: [],
     };
 
+    // Pasted Case 1.
+    // <ul>
+    //   <li>editor</li>
+    //   <ul>
+    //     <li>nested-list</li>
+    //   </ul>
+    // </ul>
+    // Pasted Case 2
+    // <ul>
+    //   <li>
+    //     editor
+    //     <ul>
+    //       <li>nested-list</li>
+    //     </ul>
+    //   </li>
+    // </ul>
     // get pasted items from the html.
     const getPastedItems = (parent) => {
+      let responseData = [];
       // get first level li elements.
       const children = Array.from(parent.querySelectorAll(`:scope > li`));
 
-      return children.map((child) => {
-        // get subitems if they exist.
-        const subItemsWrapper = child.querySelector(`:scope > ${tagToSearch}`);
-        // get subitems.
-        const subItems = subItemsWrapper ? getPastedItems(subItemsWrapper) : [];
-        // get text content of the li element.
-        const content = child?.firstChild?.textContent || '';
-
-        return {
-          content,
-          items: subItems,
-        };
+      children.map((child) => {
+        const listItem = getListItem(child);
+        responseData = responseData.concat(listItem);
       });
+
+      return responseData;
     };
+
+    const getListItem = (list) => {
+      const nestedItems = getNestedListContainers(list);
+      return {
+        content: list?.firstChild?.textContent || '',
+        items: nestedItems
+      };
+    }
+
+    const getNestedListContainers = (parent) => {
+      let responseData = [];
+      const nestedListContainers = Array.from(parent.querySelectorAll(`:scope > ${tagToSearch}`))
+
+      nestedListContainers.map((nestedListContainer) => {
+        responseData = responseData.concat(getPastedItems(nestedListContainer));
+      });
+
+      return responseData;
+    }
 
     // get pasted items.
     data.items = getPastedItems(element);

--- a/src/index.js
+++ b/src/index.js
@@ -251,9 +251,9 @@ export default class NestedList {
 
       children.map((child) => {
         if (child.tagName === tag) {
-          const nestedListContainers = getNestedListContainers(parent);
+          const nestedListGroup = getNestedListGroup(parent);
           const previousListItem = responseData.pop();
-          previousListItem.items = nestedListContainers;
+          previousListItem.items = nestedListGroup;
           responseData = responseData.concat(previousListItem);
         } else {
           const listItem = getListItem(child);
@@ -265,19 +265,19 @@ export default class NestedList {
     };
 
     const getListItem = (list) => {
-      const nestedItems = getNestedListContainers(list);
+      const nestedItems = getNestedListGroup(list);
       return {
         content: list?.firstChild?.textContent || '',
         items: nestedItems
       };
     }
 
-    const getNestedListContainers = (parent) => {
+    const getNestedListGroup = (parent) => {
       let responseData = [];
-      const nestedListContainers = Array.from(parent.querySelectorAll(`:scope > ${tagToSearch}`))
+      const nestedListGroups = Array.from(parent.querySelectorAll(`:scope > ${tagToSearch}`))
 
-      nestedListContainers.map((nestedListContainer) => {
-        responseData = responseData.concat(getPastedItems(nestedListContainer));
+      nestedListGroups.map((nestedListGroup) => {
+        responseData = responseData.concat(getPastedItems(nestedListGroup));
       });
 
       return responseData;


### PR DESCRIPTION
Current version of nested-list can render Case 2 style only.

This PR refactors `pasteHandler` to support Case 1, Case 2 and Mix of each cases.

> Pasted Case 1.
```html
    <ul>
      <li>editor</li>
      <ul>
        <li>nested-list</li>
      </ul>
    </ul>
```

> Pasted Case 2
```html
    <ul>
      <li>
        editor
        <ul>
          <li>nested-list</li>
        </ul>
      </li>
    </ul>
```

