### PR TITLE
Issue #40 - Add ability to select multiple list items at a time for formatting or deletion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -482,9 +482,9 @@ export default class NestedList {
     classes.push(styleClass);
 
     // since tag is either 'ol' or 'ul' we can safely cast it to HTMLOListElement | HTMLUListElement
-    return Dom.make(tag, [this.CSS.wrapper, ...classes]) as
-      | HTMLOListElement
-      | HTMLUListElement;
+    return Dom.make(tag, [this.CSS.wrapper, ...classes], {
+      contentEditable: (!this.readOnly).toString()
+    }) as HTMLOListElement | HTMLUListElement;
   }
 
   /**


### PR DESCRIPTION
Allows for multiple list items to be highlighted, by adding the `contenteditable` attribute to ol and ul items.
Issue: https://github.com/editor-js/nested-list/issues/40