### PR TITLE
Refactor(tabulation) Keydowns and style refactor

### DIFF
--- a/src/ListRenderer/ListRenderer.ts
+++ b/src/ListRenderer/ListRenderer.ts
@@ -12,6 +12,7 @@ export const DefaultListCssClasses = {
   item: `${CssPrefix}__item`,
   itemContent: `${CssPrefix}__item-content`,
   itemChildren: `${CssPrefix}__item-children`,
+  itemAnchor: `${CssPrefix}-anchor`,
 }
 
 /**
@@ -22,6 +23,7 @@ export interface ListCssClasses {
   item: string;
   itemContent: string;
   itemChildren: string;
+  itemAnchor: string;
 }
 
 /**
@@ -30,17 +32,16 @@ export interface ListCssClasses {
 export interface ListRendererInterface<ItemMeta> {
   /**
    * Renders wrapper for list
-   * @param level - level of nesting (0 for the rool level)
-   * @returns - created html ul element
+   * @returns - created html element
    */
-  renderWrapper: (level: number) => HTMLElement;
+  renderWrapper: () => HTMLElement;
 
   /**
    * Redners list item element
    * @param content - content of the list item
    * @returns - created html list item element
    */
-  renderItem: (content: string, meta: ItemMeta) => HTMLElement;
+  renderItem: (content: string, meta: ItemMeta, level: number) => HTMLElement | null;
 
   /**
    * Return the item content
@@ -55,4 +56,11 @@ export interface ListRendererInterface<ItemMeta> {
    * @returns {ItemMeta} Item meta object
    */
   getItemMeta: (item: Element) => ItemMeta;
+
+  /**
+   * Deletes item content with list bullet (could be checkbox or counter or bullet)
+   * @param item - item, whose content would be cleared
+   * @returns {void}
+   */
+  clearItemContent: (item: Element) => void;
 };

--- a/src/ListRenderer/OrderedListRenderer.ts
+++ b/src/ListRenderer/OrderedListRenderer.ts
@@ -42,17 +42,10 @@ export class OrderedListRenderer implements ListRendererInterface<OrderedListIte
    * @param level - level of nesting (0 for the rool level)
    * @returns - created html ol element
    */
-  renderWrapper(level: number): HTMLOListElement {
+  renderWrapper(): HTMLOListElement {
     let wrapperElement: HTMLOListElement;
 
-    /**
-     * Check if it's root level
-     */
-    if (level === 0) {
-      wrapperElement = Dom.make('ol', [OrderedListRenderer.CSS.wrapper, OrderedListRenderer.CSS.orderedList]) as HTMLOListElement;
-    } else {
-      wrapperElement = Dom.make('ol', [OrderedListRenderer.CSS.orderedList, OrderedListRenderer.CSS.itemChildren]) as HTMLOListElement;
-    }
+    wrapperElement = Dom.make('ol', [OrderedListRenderer.CSS.wrapper, OrderedListRenderer.CSS.orderedList]) as HTMLOListElement;
 
     return wrapperElement;
   }
@@ -67,6 +60,9 @@ export class OrderedListRenderer implements ListRendererInterface<OrderedListIte
       innerHTML: content,
       contentEditable: (!this.readOnly).toString(),
     });
+
+    itemWrapper.setAttribute('level', meta.level.toString());
+    itemWrapper.setAttribute('style', `--level: ${meta.level};`);
 
     itemWrapper.appendChild(itemContent);
 
@@ -94,9 +90,32 @@ export class OrderedListRenderer implements ListRendererInterface<OrderedListIte
 
   /**
    * Returns item meta, for ordered list
+   * @param {Element} item - item of the list to get meta from
    * @returns Item meta object
    */
-  getItemMeta(): OrderedListItemMeta  {
-    return {}
+  getItemMeta(item: Element): OrderedListItemMeta  {
+    const itemLevelAttribute = item.getAttribute('level');
+
+    let itemLevel: number;
+
+    if (itemLevelAttribute === null) {
+      itemLevel = 0;
+    } else {
+      try {
+        itemLevel = parseInt(itemLevelAttribute);
+      } catch {
+        itemLevel = 0;
+      };
+    }
+
+    return {
+      level: itemLevel,
+    }
   }
+
+  clearItemContent(item: Element): void {
+    const itemContent = item.querySelector(`.${OrderedListRenderer.CSS.itemContent}`);
+
+    itemContent?.remove();
+  };
 }

--- a/src/ListRenderer/UnorderedListRenderer.ts
+++ b/src/ListRenderer/UnorderedListRenderer.ts
@@ -42,17 +42,10 @@ export class UnorderedListRenderer implements ListRendererInterface<UnorderedLis
    * @param level - level of nesting (0 for the rool level)
    * @returns - created html ul element
    */
-  renderWrapper(level: number): HTMLUListElement {
+  renderWrapper(): HTMLUListElement {
     let wrapperElement: HTMLUListElement;
 
-    /**
-     * Check if it's root level
-     */
-    if (level === 0) {
-      wrapperElement = Dom.make('ul', [UnorderedListRenderer.CSS.wrapper, UnorderedListRenderer.CSS.unorderedList]) as HTMLUListElement;
-    } else {
-      wrapperElement = Dom.make('ul', [UnorderedListRenderer.CSS.unorderedList, UnorderedListRenderer.CSS.itemChildren]) as HTMLUListElement;
-    }
+    wrapperElement = Dom.make('ul', [UnorderedListRenderer.CSS.wrapper, UnorderedListRenderer.CSS.unorderedList]) as HTMLUListElement;
 
     return wrapperElement;
   }
@@ -68,6 +61,9 @@ export class UnorderedListRenderer implements ListRendererInterface<UnorderedLis
       innerHTML: content,
       contentEditable: (!this.readOnly).toString(),
     });
+
+    itemWrapper.setAttribute('level', meta.level.toString());
+    itemWrapper.setAttribute('style', `--level: ${meta.level};`);
 
     itemWrapper.appendChild(itemContent);
 
@@ -95,9 +91,32 @@ export class UnorderedListRenderer implements ListRendererInterface<UnorderedLis
 
   /**
    * Returns item meta, for unordered list
+   * @param {Element} item - item of the list to get meta from
    * @returns Item meta object
    */
-  getItemMeta(): UnorderedListItemMeta  {
-    return {}
+  getItemMeta(item: Element): UnorderedListItemMeta  {
+    const itemLevelAttribute = item.getAttribute('level');
+
+    let itemLevel: number;
+
+    if (itemLevelAttribute === null) {
+      itemLevel = 0;
+    } else {
+      try {
+        itemLevel = parseInt(itemLevelAttribute);
+      } catch {
+        itemLevel = 0;
+      };
+    }
+
+    return {
+      level: itemLevel,
+    }
   }
+
+  clearItemContent(item: Element): void {
+    const itemContent = item.querySelector(`.${UnorderedListRenderer.CSS.itemContent}`);
+
+    itemContent?.remove();
+  };
 }

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -718,30 +718,45 @@ export default class ListTabulator {
       return;
     }
 
-    const currentItemWrapper = this.list!.renderWrapper(1);
+    let currentItemChildWrapper = currentItem.querySelector(`.${DefaultListCssClasses.itemChildren}`);
+
+    if (currentItemChildWrapper === null) {
+      currentItemChildWrapper = this.list!.renderWrapper(1);
+    }
 
     let sibling = currentItem.nextElementSibling;
 
+    /**
+     * Check for trailing siblings of the current item
+     */
     while (sibling) {
-      console.log('sib', sibling)
+      /**
+       * Check for trailing siblings of the item
+       * If they exist, they should be moved to children of curret item
+       * This will let them stay on their nesting level
+       */
       if (sibling.classList.contains(DefaultListCssClasses.item)) {
-        currentItemWrapper.appendChild(sibling);
+        currentItemChildWrapper.appendChild(sibling);
       }
+
       sibling = sibling.nextElementSibling;
     }
 
-    console.log('wrapper with siblings', currentItemWrapper);
+    currentItem.appendChild(currentItemChildWrapper);
 
-    currentItem.appendChild(currentItemWrapper);
-
-    console.log('current item generated', currentItem);
-
+    /**
+     * Save caret inside the current item element
+     */
     this.caret.save();
 
-    console.log(parentItem);
-
+    /**
+     * Move current item with all childs and trailing siblings as childs after the parent
+     */
     parentItem.after(currentItem);
 
+    /**
+     * Restore caret after moving current item to other parent
+     */
     this.caret.restore();
 
     /**

--- a/src/types/ItemMeta.ts
+++ b/src/types/ItemMeta.ts
@@ -1,7 +1,12 @@
 /**
  * Meta information of each list item
  */
-export interface ItemMeta {};
+export interface ItemMeta {
+  /**
+   * Level of the current item nesting
+   */
+  level: number;
+};
 
 /**
  * Meta information of checklist item

--- a/styles/index.pcss
+++ b/styles/index.pcss
@@ -15,17 +15,7 @@
 
   &__item {
     line-height: var(--line-height);
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-template-rows: auto auto;
-    grid-template-areas:
-      "checkbox content"
-      ". child";
-    margin: 2px 0;
-
-    &-children {
-      grid-area: child;
-    }
+    display: flex;
 
     [contenteditable]{
       outline: none;
@@ -35,14 +25,19 @@
       margin-left: 8px;
       word-break: break-word;
       white-space: pre-wrap;
-      grid-area: content;
     }
 
     &::before {
-      counter-increment: item;
       margin-right: 5px;
       white-space: nowrap;
     }
+  }
+
+  &__item[level] {
+    counter-reset: item;
+    counter-increment: item;
+    --level: attr(level number);
+    padding-left: calc(var(--level) * 20px);
   }
 
   &-ordered &__item::before {
@@ -69,7 +64,6 @@
 
   &__checkbox {
     padding-top: calc((var(--line-height) - var(--size-checkbox)) / 2);
-    grid-area: checkbox;
     width: var(--size-checkbox);
     height: var(--size-checkbox);
     display: flex;


### PR DESCRIPTION
This PR is related to the #75 issue
This PR is a part of global work on List 2.0

## Problems
- Nesting is not customizable
- Can not increase nesting more than 1 time
```
1
    1.1.1
```
is currently unavailable
- Can't customize ordered list (custom numeration or starting with custom number)
## Solutions
- Now data model meta field will contain level variable
``` ts
meta: 
{
  checked?: boolean,
  level: number,  
}
```
- Refactor rendering part
Now we will have flat structure of the list, but all item will have level attribute
``` html
<ol class="list">
  <li class="cdx-list__item" level="1" style="--level: 1">Item Level 1</li>
  <li class="cdx-list__item" level="2" style="--level: 2">Item Level 2</li>
  <li class="cdx-list__item" level="1" style="--level: 1">Item Level 1</li>
  <li class="cdx-list__item" level="2" style="--level: 2">Item Level 2</li>
  <li class="cdx-list__item" level="3" style="--level: 3">Item Level 3</li>
  <li class="cdx-list__item" level="4" style="--level: 4">Item Level 4</li>
</ol>
```
- Nesting customization by `maxLevel` config option
- Add support for `<ol>` attributes in config (such as `type`, `start`, `reversed`)
## Status
- [x] Support new data model
- [ ] Refactor keydowns befaviour
- [ ] Support counters for ordered list in new format
- [ ] Add nesting customization
- [ ] Add ordered list customization for #66
- [ ] Refactor paste config
- [ ] Export all available lists into toolbox for #70
- [ ] List splitting for #30
