### PR TITLE
Bugfix (tabulator): caret saving works unexpectedly in safare

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "lint:fix": "eslint --fix"
   },
   "devDependencies": {
-    "@editorjs/editorjs": "^2.29.1",
+    "@editorjs/editorjs": "^2.31.0-rc.1",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
-    "@editorjs/caret": "^0.0.7",
+    "@editorjs/caret": "^1.0.1",
     "@editorjs/dom": "^0.0.7",
     "eslint": "^9.2.0",
     "eslint-config-codex": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@editorjs/editorjs": "^2.31.0-rc.1",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
-    "@editorjs/caret": "^1.0.1",
+    "@editorjs/caret": "^1.0.2",
     "@editorjs/dom": "^0.0.7",
     "eslint": "^9.2.0",
     "eslint-config-codex": "^2.0.0",

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -4,7 +4,7 @@ import type { NestedListConfig, ListData, ListDataStyle } from '../types/ListPar
 import type { ListItem } from '../types/ListParams';
 import type { ItemElement, ItemChildWrapperElement } from '../types/Elements';
 import { isHtmlElement } from '../utils/type-guards';
-import { getContenteditableSlice, getCaretNodeAndOffset, focus, isCaretAtStartOfInput, save as saveCaret } from '@editorjs/caret';
+import { getContenteditableSlice, getCaretNodeAndOffset, focus, isCaretAtStartOfInput } from '@editorjs/caret';
 import { DefaultListCssClasses } from '../ListRenderer';
 import type { PasteEvent } from '../types';
 import type { API, BlockAPI, PasteConfig } from '@editorjs/editorjs';
@@ -227,14 +227,10 @@ export default class ListTabulator<Renderer extends ListRenderer> {
 
     focus(deepestBlockItemContentElement);
 
-    const restore = saveCaret();
-
     /**
      * Insert trailing html to the deepest block item content
      */
     deepestBlockItemContentElement.insertAdjacentHTML('beforeend', data.items[0].content);
-
-    restore();
 
     if (this.listWrapper === undefined) {
       return;
@@ -748,7 +744,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     /**
      * Save the caret position
      */
-    const restore = saveCaret();
+    // const restore = saveCaret();
 
     /**
      * Update target item content by merging with current item html content
@@ -768,11 +764,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
        * Remove current item element
        */
       item.remove();
-
-      /**
-       * Restore the caret position
-       */
-      restore();
 
       return;
     }
@@ -810,11 +801,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
      * Remove current item element
      */
     item.remove();
-
-    /**
-     * Restore the caret position
-     */
-    restore();
   }
 
   /**

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -226,8 +226,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       return;
     }
 
-    focusItem(deepestBlockItem);
-
     /**
      * Insert trailing html to the deepest block item content
      */

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -441,6 +441,11 @@ export default class ListTabulator<Renderer extends ListRenderer> {
      */
     event.preventDefault();
 
+    /**
+     * Prevent Editor.js backspace handling
+     */
+    event.stopPropagation();
+
     this.mergeItemWithPrevious(currentItem);
   }
 
@@ -746,7 +751,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     /**
      * Set a new place for caret
      */
-    if (!targetItemContentElement) {
+    if (targetItemContentElement === null) {
       return;
     }
 

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -429,6 +429,17 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     }
 
     /**
+     * Check that current item is not first item of the list
+     * Otherwise Editor.js should handle merge
+     */
+    if (currentItem.parentNode !== this.listWrapper || currentItem.previousElementSibling !== null) {
+      /**
+       * Prevent Editor.js backspace handling
+       */
+      event.stopPropagation();
+    }
+
+    /**
      * Caret is not at start of the item
      * Then backspace button should remove letter as usual
      */
@@ -440,11 +451,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
      * Prevent default backspace behaviour
      */
     event.preventDefault();
-
-    /**
-     * Prevent Editor.js backspace handling
-     */
-    event.stopPropagation();
 
     this.mergeItemWithPrevious(currentItem);
   }

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -854,8 +854,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
 
     const prevItemChildrenList = getItemChildWrapper(prevItem);
 
-    const restore = saveCaret();
-
     /**
      * If prev item has child items, just append current to them
      * Else render new child wrapper for previous item
@@ -902,7 +900,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       prevItem.appendChild(prevItemChildrenListWrapper);
     }
 
-    restore();
+    focusItem(currentItem, false);
   }
 
   /**

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -4,7 +4,7 @@ import type { NestedListConfig, ListData, ListDataStyle } from '../types/ListPar
 import type { ListItem } from '../types/ListParams';
 import type { ItemElement, ItemChildWrapperElement } from '../types/Elements';
 import { isHtmlElement } from '../utils/type-guards';
-import { getContenteditableSlice, getCaretNodeAndOffset, focus, isCaretAtStartOfInput } from '@editorjs/caret';
+import { getContenteditableSlice, getCaretNodeAndOffset, isCaretAtStartOfInput } from '@editorjs/caret';
 import { DefaultListCssClasses } from '../ListRenderer';
 import type { PasteEvent } from '../types';
 import type { API, BlockAPI, PasteConfig } from '@editorjs/editorjs';
@@ -69,6 +69,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     if (!selection) {
       return null;
     }
+
     let currentNode = selection.anchorNode;
 
     if (!currentNode) {
@@ -225,7 +226,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       return;
     }
 
-    focus(deepestBlockItemContentElement);
+    focusItem(deepestBlockItem);
 
     /**
      * Insert trailing html to the deepest block item content
@@ -554,6 +555,12 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       const firstChildItem = currentItemChildrenList[0];
 
       this.unshiftItem(firstChildItem);
+
+      /**
+       * If first child item was been unshifted, that caret would be set to the end of the first child item
+       * Then we should set caret to the actual current item
+       */
+      focusItem(item, false);
     }
 
     /**
@@ -729,6 +736,11 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     }
 
     /**
+     * Set caret to the end of the target item
+     */
+    focusItem(targetItem, false);
+
+    /**
      * Get target item content element
      */
     const targetItemContentElement = getItemContentElement(targetItem);
@@ -739,7 +751,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     if (!targetItemContentElement) {
       return;
     }
-    focus(targetItemContentElement, false);
 
     /**
      * Update target item content by merging with current item html content

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -742,11 +742,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     focus(targetItemContentElement, false);
 
     /**
-     * Save the caret position
-     */
-    // const restore = saveCaret();
-
-    /**
      * Update target item content by merging with current item html content
      */
     targetItemContentElement.insertAdjacentHTML('beforeend', currentItemContent);

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -527,11 +527,9 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       item.appendChild(currentItemChildWrapper);
     }
 
-    const restore = saveCaret();
-
     parentItem.after(item);
 
-    restore();
+    focusItem(item, false);
 
     /**
      * If previous parent's children list is now empty, remove it.

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ export default class NestedList {
   /**
    * Tool's configuration
    */
-  private config: NestedListConfig;
+  private config: NestedListConfig | undefined;
 
   /**
    * Default list style formes as passed default list style from config or 'ordered' as default

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,12 +33,19 @@
   resolved "https://registry.yarnpkg.com/@codexteam/icons/-/icons-0.3.2.tgz#b7aed0ba7b344e07953101f5476cded570d4f150"
   integrity sha512-P1ep2fHoy0tv4wx85eic+uee5plDnZQ1Qa6gDfv7eHPkCXorMtVqJhzMb75o1izogh6G7380PqmFDXV3bW3Pig==
 
-"@editorjs/caret@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@editorjs/caret/-/caret-0.0.7.tgz#4197786834e51eea057c5af89c7383daf70fd8a0"
-  integrity sha512-xMTkSnqZXfAAtnf8JI3vV4L+MWdQpWGQ/x54Szj6ZuEIyk70d1XTAGU1eQvIU5i2CJeT5qDNnCk6+OXnFdFasg==
+"@editorjs/caret@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@editorjs/caret/-/caret-1.0.1.tgz#0d33ca67a2d29d09fdea10d3d30b660f0abc7cfd"
+  integrity sha512-yMewrc/dndBbgmluFory0GbVWXnD9rhcE/xgwM0ecHWQodyfY3ZIJLvSQhf+BbgncitMlUG/FYqjJCL2Axi4+g==
   dependencies:
-    "@editorjs/dom" "^0.0.7"
+    "@editorjs/dom" "^1.0.0"
+
+"@editorjs/caret@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@editorjs/caret/-/caret-1.0.2.tgz#8d7c90503caaff553d973968bb24c4ffe5d9a993"
+  integrity sha512-V1tmvNhTOLAHiJhZRtL26iKe0bs6tH+yWg6FO/v+ydsYbw16y4tMMDLhrgIcYppKmi7tt3t14prdrI1kUNPYcQ==
+  dependencies:
+    "@editorjs/dom" "^1.0.0"
 
 "@editorjs/dom@^0.0.7":
   version "0.0.7"
@@ -47,15 +54,29 @@
   dependencies:
     "@editorjs/helpers" "^0.0.7"
 
-"@editorjs/editorjs@^2.29.1":
-  version "2.30.5"
-  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.30.5.tgz#c1a6fc2b99f567a0271408c0edd51d3da21b4534"
-  integrity sha512-sE7m/UPbuf+nSGjv9cmWggFsfvtYlgEX7PCby2lZWvOsOLbRxuLT+ZYlwbWshD+8BFJwiAmBj9e+ScZcOjCzeg==
+"@editorjs/dom@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@editorjs/dom/-/dom-1.0.0.tgz#ddf7f17651a091570766c5fa44c89ecf8a183c82"
+  integrity sha512-P5qZaQaG8NQXm2XuEDlcfDm8S1Kvdegwf0E/ld2RnwZquY5l27hufaW57w0SikT75mscr+dARQ68Gx/xEQEUKw==
+  dependencies:
+    "@editorjs/helpers" "^1.0.0"
+
+"@editorjs/editorjs@^2.31.0-rc.1":
+  version "2.31.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.31.0-rc.1.tgz#9df90789b7084b7fc982a221e841098f7e1de35d"
+  integrity sha512-AZrw9jukRPKwAG5gQGb4eSp8Sc6rWUCrnMXMM6uf1yCyzx1piKuAMvHFGR5IIBHoa+7coy7kNyMwtGu9tjf+dg==
+  dependencies:
+    "@editorjs/caret" "^1.0.1"
 
 "@editorjs/helpers@^0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@editorjs/helpers/-/helpers-0.0.7.tgz#2156ec7b60a133d1e1ff87c50eb09b95b0a40ce0"
   integrity sha512-jMFbtfWKip6mSS1Pyhr1ShyOfPKfxg1Z2ESRExyXJrwjWnPF7Xqipzsig8R6ZfJDXVnvhRcKNwQcHGQZuYMjkA==
+
+"@editorjs/helpers@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@editorjs/helpers/-/helpers-1.0.0.tgz#4b0e0868e51e2772a73212f4aac5aff553725894"
+  integrity sha512-ih4yCm+x+7X9XCn1zxfNous2LQX8ZYMyTHMLdgbyjBf0Opf8GdLxVjdzSjkA+0mUp1tUe3JgWW3FTisYcSnbQA==
 
 "@es-joy/jsdoccomment@~0.46.0":
   version "0.46.0"


### PR DESCRIPTION
## Problem
In safari after saving and restoring caret with
```ts
restore = save()

restore()
```
exception raises on the following action

## Solution
Refactored list tabulator for it not to use saving and restoring caret
Now we use `focusItem()` method instead 