### PR TITLE
chore(toolbox): export all lists into toolbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,10 +57,11 @@
    -->
 
   <!-- Load Editor.js's Core -->
-  <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+  <!-- <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script> -->
 
   <!-- Initialization -->
   <script type="module">
+    import EditorJS from '@editorjs/editorjs'
     import List from './src/index.ts';
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,10 +43,29 @@ export default class NestedList {
    * title - title to show in toolbox
    */
   public static get toolbox(): ToolboxConfig {
-    return {
-      icon: IconListNumbered,
-      title: 'List',
-    };
+    return [
+      {
+        icon: IconListBulleted,
+        title: 'Unordered List',
+        data: {
+          style: 'unordered',
+        },
+      },
+      {
+        icon: IconListNumbered,
+        title: 'Ordered List',
+        data: {
+          style: 'ordered',
+        },
+      },
+      {
+        icon: IconChecklist,
+        title: 'Checklist',
+        data: {
+          style: 'checklist',
+        },
+      },
+    ];
   }
 
   /**
@@ -177,9 +196,9 @@ export default class NestedList {
     this.block = block;
 
     /**
-     * Set the default list style from the config or presetted 'ordered'.
+     * Set the default list style from the config or presetted 'unordered'.
      */
-    this.defaultListStyle = this.config?.defaultStyle || 'ordered';
+    this.defaultListStyle = this.config?.defaultStyle || 'unordered';
 
     const initialData = {
       style: this.defaultListStyle,


### PR DESCRIPTION
## Problem
Now only harcoded list style (ordered list) is exported to toolbox
It is not responsible to the `config.defaultStyle` as mentioned in #70 

## Solution
Export all available lists to the toolbar
![image](https://github.com/user-attachments/assets/1523de3a-e125-4aeb-b32a-e38f4dd9edb3)

## Related problems
- Now all lists displayed with the same shortcut
- When i actually use shortcut, convertion config is triggered (`static getter`)
I expect to convert current block to the `NestedList` with `defaultStyle`, and now paste config uses hardcoded `unordered` style

Note that related problems should be solved in Editor.js 
After that hardcoded list style should be removed from convertionConfig 