### PR TITLE
Improvement (conversion-config): Shortcut converts blocks respectfully to the config.defaultStyle

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:fix": "eslint --fix"
   },
   "devDependencies": {
-    "@editorjs/editorjs": "^2.31.0-rc.1",
+    "@editorjs/editorjs": "^2.31.0-rc.2",
     "@typescript-eslint/eslint-plugin": "^7.13.1",
     "@typescript-eslint/parser": "^7.13.1",
     "@editorjs/caret": "^1.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import type { API, BlockAPI, PasteConfig, ToolboxConfig } from '@editorjs/editorjs';
 import type {
   BlockToolConstructorOptions,
+  ToolConfig,
   TunesMenuConfig
 } from '@editorjs/editorjs/types/tools';
 import { IconListBulleted, IconListNumbered, IconChecklist } from '@codexteam/icons';
@@ -94,13 +95,13 @@ export default class NestedList {
      * @param content - contents string
      * @returns - list data formed from contents string
      */
-    import: (content: string) => ListData;
+    import: (content: string, config: ToolConfig) => ListData;
   } {
     return {
       export: (data) => {
         return NestedList.joinRecursive(data);
       },
-      import: (content) => {
+      import: (content, config) => {
         return {
           items: [
             {
@@ -109,7 +110,8 @@ export default class NestedList {
               items: [],
             },
           ],
-          style: 'unordered',
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          style: config?.defaultStyle !== undefined ? config.defaultStyle : 'unordered',
         };
       },
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export default class NestedList {
      * @param content - contents string
      * @returns - list data formed from contents string
      */
-    import: (content: string, config: ToolConfig) => ListData;
+    import: (content: string, config: ToolConfig<NestedListConfig>) => ListData;
   } {
     return {
       export: (data) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,6 @@ export default class NestedList {
               items: [],
             },
           ],
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
           style: config?.defaultStyle !== undefined ? config.defaultStyle : 'unordered',
         };
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,10 +61,10 @@
   dependencies:
     "@editorjs/helpers" "^1.0.0"
 
-"@editorjs/editorjs@^2.31.0-rc.1":
-  version "2.31.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.31.0-rc.1.tgz#9df90789b7084b7fc982a221e841098f7e1de35d"
-  integrity sha512-AZrw9jukRPKwAG5gQGb4eSp8Sc6rWUCrnMXMM6uf1yCyzx1piKuAMvHFGR5IIBHoa+7coy7kNyMwtGu9tjf+dg==
+"@editorjs/editorjs@^2.31.0-rc.2":
+  version "2.31.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@editorjs/editorjs/-/editorjs-2.31.0-rc.2.tgz#887852655f288a2b7f0d966962d4a1d041da07e4"
+  integrity sha512-KSB8B5PDtZ1Ea9flGGokgrfBh2ZproTCGwvt5n1CIGt/T2mmSPiYa4woVK0BP8MHbO/weACP2T02brPGNTQenA==
   dependencies:
     "@editorjs/caret" "^1.0.1"
 


### PR DESCRIPTION
## Problem
Now conversion config converted current block to the nested-list with hardcoded `unordered` style

## Solution
Since https://github.com/codex-team/editor.js/pull/2848
config could be passed to the `conversionConfig.import` method
Now conversion of the block without actually choosing style of the `nested-list` (only in case of the shourtcut usage) will work respectfully to the `config.defaultStyle`

## Changes
- Updated editorjs to the latest (`2.31.0-rc.2`)
- `conversionConfig.import` method takes config and uses it `config.defaultStyle` on conversion

Related: #81 