### PR TITLE
feat(properties): implement counterType config property

### DIFF
--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -193,10 +193,10 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     }
 
     /**
-     * Set countersType value from initial data
+     * Set counterType value from initial data
      */
-    if (this.data.countersType !== undefined) {
-      this.changeCounters(this.data.countersType);
+    if (this.data.counterType !== undefined) {
+      this.changeCounters(this.data.counterType);
     }
 
     return this.listWrapper;
@@ -241,7 +241,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     if (this.data.style === 'ordered') {
       dataToSave = {
         start: this.data.start,
-        countersType: this.data.countersType,
+        counterType: this.data.counterType,
         ...dataToSave,
       };
     }
@@ -426,7 +426,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
   public changeCounters(counterType: OlCounterType): void {
     this.listWrapper!.style.setProperty('--list-counter-type', counterType);
 
-    this.data.countersType = counterType;
+    this.data.counterType = counterType;
   }
 
   /**

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -19,6 +19,7 @@ import { getItemChildWrapper } from '../utils/getItemChildWrapper';
 import { removeChildWrapperIfEmpty } from '../utils/removeChildWrapperIfEmpty';
 import { getItemContentElement } from '../utils/getItemContentElement';
 import { focusItem } from '../utils/focusItem';
+import type { OlCounterType } from '../types/OlCounterType';
 
 /**
  * Class that is responsible for list tabulation
@@ -191,6 +192,13 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       this.changeStartWith(this.data.start);
     }
 
+    /**
+     * Set countersType value from initial data
+     */
+    if (this.data.countersType !== undefined) {
+      this.changeCounters(this.data.countersType);
+    }
+
     return this.listWrapper;
   }
 
@@ -233,6 +241,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     if (this.data.style === 'ordered') {
       dataToSave = {
         start: this.data.start,
+        countersType: this.data.countersType,
         ...dataToSave,
       };
     }
@@ -408,6 +417,16 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     this.listWrapper!.style.setProperty('counter-reset', `item ${index - 1}`);
 
     this.data.start = index;
+  }
+
+  /**
+   * Changes ordered list counterType property value
+   * @param counterType - new value of the counterType value
+   */
+  public changeCounters(counterType: OlCounterType): void {
+    this.listWrapper!.style.setProperty('--list-counter-type', counterType);
+
+    this.data.countersType = counterType;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,7 +339,8 @@ export default class NestedList {
       /**
        * For each counter type in OlCounterType create toolbox item
        */
-      OlCounterTypesMap.keys().forEach((counterType) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      OlCounterTypesMap.keys().forEach((counterType: string) => {
         orderedListCountersTunes.children.items!.push({
           name: counterType,
           title: this.api.i18n.t(counterType),

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,8 +214,8 @@ export default class NestedList {
     /**
      * Assign default value of the property for the ordered list
      */
-    if (this.listStyle === 'ordered' && this.data.countersType === undefined) {
-      this.data.countersType = 'numeric';
+    if (this.listStyle === 'ordered' && this.data.counterType === undefined) {
+      this.data.counterType = 'numeric';
     }
 
     this.changeTabulatorByStyle();
@@ -343,7 +343,7 @@ export default class NestedList {
         orderedListCountersTunes.children.items!.push({
           name: counterType,
           title: this.api.i18n.t(counterType),
-          isActive: this.data.countersType === OlCounterTypesMap.get(counterType),
+          isActive: this.data.counterType === OlCounterTypesMap.get(counterType),
           closeOnActivate: true,
           onActivate: () => {
             this.changeCounters(OlCounterTypesMap.get(counterType) as OlCounterType);
@@ -366,7 +366,7 @@ export default class NestedList {
   private changeCounters(counterType: OlCounterType): void {
     this.list?.changeCounters(counterType);
 
-    this.data.countersType = counterType;
+    this.data.counterType = counterType;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,8 +349,6 @@ export default class NestedList {
           onActivate: () => {
             this.changeCounters(OlCounterTypesMap.get(counterType) as OlCounterType);
           },
-          // @ts-expect-error ts(2820) can not use PopoverItem enum from editor.js types
-          type: 'default',
         });
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,7 +267,6 @@ export default class NestedList {
   public renderSettings(): MenuConfigItem[] {
     const defaultTunes: MenuConfigItem[] = [
       {
-        name: 'unordered' as const,
         label: this.api.i18n.t('Unordered'),
         icon: IconListBulleted,
         closeOnActivate: true,
@@ -277,7 +276,6 @@ export default class NestedList {
         },
       },
       {
-        name: 'ordered' as const,
         label: this.api.i18n.t('Ordered'),
         icon: IconListNumbered,
         closeOnActivate: true,
@@ -287,7 +285,6 @@ export default class NestedList {
         },
       },
       {
-        name: 'checklist' as const,
         label: this.api.i18n.t('Checklist'),
         icon: IconChecklist,
         closeOnActivate: true,
@@ -313,12 +310,10 @@ export default class NestedList {
 
       const orderedListTunes: MenuConfigItem[] = [
         {
-          name: 'start with' as const,
           label: this.api.i18n.t('Start with'),
           children: {
             items: [
               {
-                name: 'start with input',
                 element: startWithElement,
                 // @ts-expect-error ts(2820) can not use PopoverItem enum from editor.js types
                 type: 'html',
@@ -329,7 +324,6 @@ export default class NestedList {
       ];
 
       const orderedListCountersTunes: MenuConfigItem = {
-        name: 'counter types' as const,
         label: this.api.i18n.t('Counters type'),
         children: {
           items: [],
@@ -342,7 +336,6 @@ export default class NestedList {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       OlCounterTypesMap.keys().forEach((counterType: string) => {
         orderedListCountersTunes.children.items!.push({
-          name: counterType,
           title: this.api.i18n.t(counterType),
           isActive: this.data.counterType === OlCounterTypesMap.get(counterType),
           closeOnActivate: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,7 +339,7 @@ export default class NestedList {
       /**
        * For each counter type in OlCounterType create toolbox item
        */
-      OlCounterTypesMap.keys().forEach((counterType: string) => {
+      OlCounterTypesMap.keys().forEach((counterType) => {
         orderedListCountersTunes.children.items!.push({
           name: counterType,
           title: this.api.i18n.t(counterType),

--- a/src/styles/list.pcss
+++ b/src/styles/list.pcss
@@ -3,7 +3,7 @@
   padding: 0;
   outline: none;
   counter-reset: item;
-  list-style: none;
+  --list-counter-type: numeric;
   --radius-border: 5px;
   --checkbox-background: #fff;
   --color-border: #C9C9C9;
@@ -46,7 +46,7 @@
   }
 
   &-ordered &__item::before {
-    content: counters(item, ".") ".";
+    content: counters(item, ".", var(--list-counter-type)) ".";
   }
 
   &-ordered {

--- a/src/types/ListParams.ts
+++ b/src/types/ListParams.ts
@@ -30,7 +30,7 @@ export interface ListData {
   /**
    * Counters type used only in ordered list
    */
-  countersType?: OlCounterType;
+  counterType?: OlCounterType;
 }
 
 /**

--- a/src/types/ListParams.ts
+++ b/src/types/ListParams.ts
@@ -1,4 +1,5 @@
 import type { ChecklistItemMeta, OrderedListItemMeta, UnorderedListItemMeta } from './ItemMeta';
+import type { OlCounterType } from './OlCounterType';
 
 /**
  * list style to make list as ordered or unordered
@@ -18,14 +19,18 @@ export interface ListData {
    */
   items: ListItem[];
   /**
-   * Start property used only in ordered list
-   */
-  start?: number;
-  /**
    * Max level of the nesting in list
    * If nesting is not needed, it could be set to 1
    */
   maxLevel?: number;
+  /**
+   * Start property used only in ordered list
+   */
+  start?: number;
+  /**
+   * Counters type used only in ordered list
+   */
+  countersType?: OlCounterType;
 }
 
 /**

--- a/src/types/OlCounterType.ts
+++ b/src/types/OlCounterType.ts
@@ -1,0 +1,31 @@
+export type OlCounterType = 'numeric' | 'upper-roman' | 'lower-roman' | 'upper-alpha' | 'lower-alpha';
+
+/**
+ * Enum that represents all of the supported styles of the counters for ordered list
+ */
+export const OlCounterTypesMap = new Map<string, string>([
+  /**
+   * Value that represents default arabic numbers for counters
+   */
+  ['Numeric', 'numeric'],
+
+  /**
+   * Value that represents lower roman numbers for counteres
+   */
+  ['Lower Roman', 'lower-roman'],
+
+  /**
+   * Value that represents upper roman numbers for counters
+   */
+  ['Upper Roman', 'upper-roman'],
+
+  /**
+   * Value that represents lower alpha characters for counters
+   */
+  ['Lower Alpha', 'lower-alpha'],
+
+  /**
+   * Value that represents upper alpha characters for counters
+   */
+  ['Upper Alpha', 'upper-alpha'],
+]);


### PR DESCRIPTION
## Problem
For now we can't customize counters for ordered list

## Solution
Added counterType customisation in toolbox
![image](https://github.com/user-attachments/assets/6df946d5-bb99-4043-924c-35f7fc527351)
Now we support:
- `numeric` (default)
- `lower-roman`
- `upper-roman`
- `lower-alpha`
- `upper-alpha`

## Changes
### NestedList
- In constructor we check that list is ordered and if it is, we assign default value to the `data.counterType` if it is not specified
- Export customisation toolbox items into toolbox
- Change `data.counterType` value when related toolbox triggered
### Tabulator
- Change own `data.counterType` and set list's `--list-counter-type` to the concrete value, when `NestedList` calls `changeCounterType()` method
- On save, check, if list is ordered and add counterType to the `dataToSave` variable
### Styles
- Added variable that is responsible for list counter type
### Types
- Added union type that represents supported values for `data.counterType`
- Added Map that is responsible for getting exact `counterType` by it's name displayed in toolbox item