### PR TITLE
Fix (utils): Fix remove wrapper if empty

### DIFF
--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -613,15 +613,10 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     focusItem(item, false);
 
     /**
-     * If previous parent's children list is now empty, remove it.
+     * If parent item has empty child wrapper after unshifting of the current item, then we need to remove child wrapper
+     * This case could be reached if the only child item of the parent was unshifted
      */
-    const parentItemChildWrapper = getItemChildWrapper(parentItem);
-
-    if (!parentItemChildWrapper) {
-      return;
-    }
-
-    removeChildWrapperIfEmpty(parentItemChildWrapper);
+    removeChildWrapperIfEmpty(parentItem);
   }
 
   /**
@@ -857,14 +852,11 @@ export default class ListTabulator<Renderer extends ListRenderer> {
        */
       item.remove();
 
-      const targetItemChildWrapper = getItemChildWrapper(targetItem);
-
       /**
-       * Remove target item child wrapper if it is empty
+       * If target item has empty child wrapper after merge, we need to remove child wrapper
+       * This case could be reached if the only child item of the target was merged with target
        */
-      if (targetItemChildWrapper !== null) {
-        removeChildWrapperIfEmpty(targetItemChildWrapper);
-      }
+      removeChildWrapperIfEmpty(targetItem);
 
       return;
     }
@@ -1001,14 +993,12 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       prevItem.appendChild(prevItemChildrenListWrapper);
     }
 
-    const currentItemChildWrapper = getItemChildWrapper(currentItem);
-
     /**
-     * Remove child wrapper after moving all children
+     * Remove child wrapper of the current item if it is empty after adding the tab
+     * This case would be reached, because after adding tab current item will have same nesting level with children
+     * So its child wrapper would be empty
      */
-    if (currentItemChildWrapper !== null) {
-      removeChildWrapperIfEmpty(currentItemChildWrapper);
-    }
+    removeChildWrapperIfEmpty(currentItem);
 
     focusItem(currentItem, false);
   }

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -857,6 +857,15 @@ export default class ListTabulator<Renderer extends ListRenderer> {
        */
       item.remove();
 
+      const targetItemChildWrapper = getItemChildWrapper(targetItem);
+
+      /**
+       * Remove target item child wrapper if it is empty
+       */
+      if (targetItemChildWrapper !== null) {
+        removeChildWrapperIfEmpty(targetItemChildWrapper);
+      }
+
       return;
     }
 

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -992,6 +992,15 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       prevItem.appendChild(prevItemChildrenListWrapper);
     }
 
+    const currentItemChildWrapper = getItemChildWrapper(currentItem);
+
+    /**
+     * Remove child wrapper after moving all children
+     */
+    if (currentItemChildWrapper !== null) {
+      removeChildWrapperIfEmpty(currentItemChildWrapper);
+    }
+
     focusItem(currentItem, false);
   }
 

--- a/src/utils/removeChildWrapperIfEmpty.ts
+++ b/src/utils/removeChildWrapperIfEmpty.ts
@@ -1,15 +1,31 @@
-import type { ItemChildWrapperElement } from '../types/Elements';
+import { DefaultListCssClasses } from '../ListRenderer';
+import type { ItemChildWrapperElement, ItemElement } from '../types/Elements';
 import { getChildItems } from './getChildItems';
+import { getItemChildWrapper } from './getItemChildWrapper';
 
 /**
  * Method that will remove passed child wrapper if it has no child items
- * @param childWrapper - childWrapper to be removed if it is empty
+ * @param element - child wrapper or actual item, from where we get child wrapper
  */
-export function removeChildWrapperIfEmpty(childWrapper: ItemChildWrapperElement): void {
+// eslint-disable-next-line @typescript-eslint/no-duplicate-type-constituents
+export function removeChildWrapperIfEmpty(element: ItemChildWrapperElement | ItemElement): void {
+  let itemChildWrapper: HTMLElement | null = element;
+
+  /**
+   * If passed element is list item than get item's child wrapper
+   */
+  if (element.classList.contains(DefaultListCssClasses.item)) {
+    itemChildWrapper = getItemChildWrapper(element);
+  }
+
+  if (itemChildWrapper === null) {
+    return;
+  }
+
   /**
    * Check that there is at least one item
    */
-  if (getChildItems(childWrapper).length === 0) {
-    childWrapper.remove();
+  if (getChildItems(itemChildWrapper).length === 0) {
+    itemChildWrapper.remove();
   }
 }

--- a/src/utils/removeChildWrapperIfEmpty.ts
+++ b/src/utils/removeChildWrapperIfEmpty.ts
@@ -6,7 +6,10 @@ import { getChildItems } from './getChildItems';
  * @param childWrapper - childWrapper to be removed if it is empty
  */
 export function removeChildWrapperIfEmpty(childWrapper: ItemChildWrapperElement): void {
-  if (getChildItems(childWrapper) === null) {
+  /**
+   * Check that there is at least one item
+   */
+  if (getChildItems(childWrapper).length === 0) {
     childWrapper.remove();
   }
 }


### PR DESCRIPTION
## Problem
Since `getChildItems()` method can return only array of items, we can not compare it with null

## Solution
- We should check that `getChildItems()` not empty list
- We should remove empty child wrappers on shifttab and backspace