### PR TITLE
Feat (data compatibility): Add normalization for List tool data

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,8 +191,19 @@
                 }
               ]
             }
-          }
-        ]
+          },
+          {
+            type : 'List',
+            data : {
+            style : "checklist",
+            items : [
+              "This is List tool data",
+              "That would be displayed",
+              "In Nested List tool"
+              ],
+            },
+          },
+        ],
       },
       onReady: function(){
         saveButton.click();

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -1,6 +1,6 @@
 import { OrderedListRenderer } from '../ListRenderer/OrderedListRenderer';
 import { UnorderedListRenderer } from '../ListRenderer/UnorderedListRenderer';
-import type { NestedListConfig, ListData, NestedListDataStyle } from '../types/ListParams';
+import type { NestedListConfig, ListData, ListDataStyle } from '../types/ListParams';
 import type { ListItem } from '../types/ListParams';
 import type { ItemElement, ItemChildWrapperElement } from '../types/Elements';
 import { isHtmlElement } from '../utils/type-guards';
@@ -362,7 +362,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    */
   public pasteHandler(element: PasteEvent['detail']['data']): ListData {
     const { tagName: tag } = element;
-    let style: NestedListDataStyle = 'unordered';
+    let style: ListDataStyle = 'unordered';
     let tagToSearch: string;
 
     // set list style and tag to search.

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -1,7 +1,7 @@
 import { OrderedListRenderer } from '../ListRenderer/OrderedListRenderer';
 import { UnorderedListRenderer } from '../ListRenderer/UnorderedListRenderer';
-import type { NestedListConfig, ListData, ListDataStyle } from '../types/ListParams';
-import type { ListItem } from '../types/ListParams';
+import type { NestedListConfig, NestedListData, NestedListDataStyle } from '../types/ListParams';
+import type { NestedListItem } from '../types/ListParams';
 import type { ItemElement, ItemChildWrapperElement } from '../types/Elements';
 import { isHtmlElement } from '../utils/type-guards';
 import { getContenteditableSlice, getCaretNodeAndOffset, isCaretAtStartOfInput } from '@editorjs/caret';
@@ -43,7 +43,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
   /**
    * Full content of the list
    */
-  private data: ListData;
+  private data: NestedListData;
 
   /**
    * Editor block api
@@ -207,14 +207,14 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * @param wrapper - optional argument wrapper
    * @returns whole list saved data if wrapper not passes, otherwise will return data of the passed wrapper
    */
-  public save(wrapper?: ItemChildWrapperElement): ListData {
+  public save(wrapper?: ItemChildWrapperElement): NestedListData {
     const listWrapper = wrapper ?? this.listWrapper;
 
     /**
      * The method for recursive collecting of the child items
      * @param parent - where to find items
      */
-    const getItems = (parent: ItemChildWrapperElement): ListItem[] => {
+    const getItems = (parent: ItemChildWrapperElement): NestedListItem[] => {
       const children = getChildItems(parent);
 
       return children.map((el) => {
@@ -233,7 +233,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
 
     const composedListItems = listWrapper ? getItems(listWrapper) : [];
 
-    let dataToSave: ListData = {
+    let dataToSave: NestedListData = {
       style: this.data.style,
       items: composedListItems,
     };
@@ -268,7 +268,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * Other items of the next List would be appended to the current list without any changes in nesting levels
    * @param data - data of the second list to be merged with current
    */
-  public merge(data: ListData): void {
+  public merge(data: NestedListData): void {
     /**
      * Get list of all levels children of the previous item
      */
@@ -360,9 +360,9 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * @param element - html element that contains whole list
    * @todo - refactor and move to nested list instance
    */
-  public pasteHandler(element: PasteEvent['detail']['data']): ListData {
+  public pasteHandler(element: PasteEvent['detail']['data']): NestedListData {
     const { tagName: tag } = element;
-    let style: ListDataStyle = 'unordered';
+    let style: NestedListDataStyle = 'unordered';
     let tagToSearch: string;
 
     // set list style and tag to search.
@@ -377,13 +377,13 @@ export default class ListTabulator<Renderer extends ListRenderer> {
         tagToSearch = 'ul';
     }
 
-    const data: ListData = {
+    const data: NestedListData = {
       style,
       items: [],
     };
 
     // get pasted items from the html.
-    const getPastedItems = (parent: Element): ListItem[] => {
+    const getPastedItems = (parent: Element): NestedListItem[] => {
       // get first level li elements.
       const children = Array.from(parent.querySelectorAll(`:scope > li`));
 
@@ -1030,7 +1030,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * @param meta - meta used in list item rendering
    * @returns html element of the rendered item
    */
-  private renderItem(itemContent: ListItem['content'], meta?: ListItem['meta']): ItemElement {
+  private renderItem(itemContent: NestedListItem['content'], meta?: NestedListItem['meta']): ItemElement {
     const itemMeta = meta ?? this.renderer.composeDefaultMeta();
 
     switch (true) {
@@ -1050,7 +1050,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * @param items - list data used in item rendering
    * @param parentElement - where to append passed items
    */
-  private appendItems(items: ListItem[], parentElement: Element): void {
+  private appendItems(items: NestedListItem[], parentElement: Element): void {
     items.forEach((item) => {
       const itemEl = this.renderItem(item.content, item.meta);
 

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -1,7 +1,7 @@
 import { OrderedListRenderer } from '../ListRenderer/OrderedListRenderer';
 import { UnorderedListRenderer } from '../ListRenderer/UnorderedListRenderer';
-import type { NestedListConfig, NestedListData, NestedListDataStyle } from '../types/ListParams';
-import type { NestedListItem } from '../types/ListParams';
+import type { NestedListConfig, ListData, NestedListDataStyle } from '../types/ListParams';
+import type { ListItem } from '../types/ListParams';
 import type { ItemElement, ItemChildWrapperElement } from '../types/Elements';
 import { isHtmlElement } from '../utils/type-guards';
 import { getContenteditableSlice, getCaretNodeAndOffset, isCaretAtStartOfInput } from '@editorjs/caret';
@@ -43,7 +43,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
   /**
    * Full content of the list
    */
-  private data: NestedListData;
+  private data: ListData;
 
   /**
    * Editor block api
@@ -207,14 +207,14 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * @param wrapper - optional argument wrapper
    * @returns whole list saved data if wrapper not passes, otherwise will return data of the passed wrapper
    */
-  public save(wrapper?: ItemChildWrapperElement): NestedListData {
+  public save(wrapper?: ItemChildWrapperElement): ListData {
     const listWrapper = wrapper ?? this.listWrapper;
 
     /**
      * The method for recursive collecting of the child items
      * @param parent - where to find items
      */
-    const getItems = (parent: ItemChildWrapperElement): NestedListItem[] => {
+    const getItems = (parent: ItemChildWrapperElement): ListItem[] => {
       const children = getChildItems(parent);
 
       return children.map((el) => {
@@ -233,7 +233,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
 
     const composedListItems = listWrapper ? getItems(listWrapper) : [];
 
-    let dataToSave: NestedListData = {
+    let dataToSave: ListData = {
       style: this.data.style,
       items: composedListItems,
     };
@@ -268,7 +268,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * Other items of the next List would be appended to the current list without any changes in nesting levels
    * @param data - data of the second list to be merged with current
    */
-  public merge(data: NestedListData): void {
+  public merge(data: ListData): void {
     /**
      * Get list of all levels children of the previous item
      */
@@ -360,7 +360,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * @param element - html element that contains whole list
    * @todo - refactor and move to nested list instance
    */
-  public pasteHandler(element: PasteEvent['detail']['data']): NestedListData {
+  public pasteHandler(element: PasteEvent['detail']['data']): ListData {
     const { tagName: tag } = element;
     let style: NestedListDataStyle = 'unordered';
     let tagToSearch: string;
@@ -377,13 +377,13 @@ export default class ListTabulator<Renderer extends ListRenderer> {
         tagToSearch = 'ul';
     }
 
-    const data: NestedListData = {
+    const data: ListData = {
       style,
       items: [],
     };
 
     // get pasted items from the html.
-    const getPastedItems = (parent: Element): NestedListItem[] => {
+    const getPastedItems = (parent: Element): ListItem[] => {
       // get first level li elements.
       const children = Array.from(parent.querySelectorAll(`:scope > li`));
 
@@ -1030,7 +1030,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * @param meta - meta used in list item rendering
    * @returns html element of the rendered item
    */
-  private renderItem(itemContent: NestedListItem['content'], meta?: NestedListItem['meta']): ItemElement {
+  private renderItem(itemContent: ListItem['content'], meta?: ListItem['meta']): ItemElement {
     const itemMeta = meta ?? this.renderer.composeDefaultMeta();
 
     switch (true) {
@@ -1050,7 +1050,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * @param items - list data used in item rendering
    * @param parentElement - where to append passed items
    */
-  private appendItems(items: NestedListItem[], parentElement: Element): void {
+  private appendItems(items: ListItem[], parentElement: Element): void {
     items.forEach((item) => {
       const itemEl = this.renderItem(item.content, item.meta);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolConfig
 } from '@editorjs/editorjs/types/tools';
 import { IconListBulleted, IconListNumbered, IconChecklist } from '@codexteam/icons';
-import type { NestedListConfig, ListData, NestedListDataStyle, ListItem, OldListData } from './types/ListParams';
+import type { NestedListConfig, ListData, ListDataStyle, ListItem, OldListData } from './types/ListParams';
 import ListTabulator from './ListTabulator';
 import { CheckListRenderer, OrderedListRenderer, UnorderedListRenderer } from './ListRenderer';
 import type { ListRenderer } from './types/ListRenderer';
@@ -124,7 +124,7 @@ export default class NestedList {
   /**
    * Get list style name
    */
-  private get listStyle(): NestedListDataStyle {
+  private get listStyle(): ListDataStyle {
     return this.data.style || this.defaultListStyle;
   }
 
@@ -132,7 +132,7 @@ export default class NestedList {
    * Set list style
    * @param style - new style to set
    */
-  private set listStyle(style: NestedListDataStyle) {
+  private set listStyle(style: ListDataStyle) {
     this.data.style = style;
 
     this.changeTabulatorByStyle();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolConfig
 } from '@editorjs/editorjs/types/tools';
 import { IconListBulleted, IconListNumbered, IconChecklist } from '@codexteam/icons';
-import type { NestedListConfig, ListData, ListDataStyle, ListItem } from './types/ListParams';
+import type { NestedListConfig, NestedListData, NestedListDataStyle, NestedListItem, ListData } from './types/ListParams';
 import ListTabulator from './ListTabulator';
 import { CheckListRenderer, OrderedListRenderer, UnorderedListRenderer } from './ListRenderer';
 import type { ListRenderer } from './types/ListRenderer';
@@ -18,11 +18,12 @@ import { type OlCounterType, OlCounterTypesMap } from './types/OlCounterType';
 import './styles/list.pcss';
 import './styles/input.pcss';
 import stripNumbers from './utils/stripNumbers';
+import normalizeData from './utils/normalizeData';
 
 /**
  * Constructor Params for Nested List Tool, use to pass initial data and settings
  */
-export type ListParams = BlockToolConstructorOptions<ListData, NestedListConfig>;
+export type ListParams = BlockToolConstructorOptions<NestedListData | ListData, NestedListConfig>;
 
 /**
  * Default class of the component used in editor
@@ -92,14 +93,14 @@ export default class NestedList {
      * @param data - current list data
      * @returns - contents string formed from list data
      */
-    export: (data: ListData) => string;
+    export: (data: NestedListData) => string;
 
     /**
      * Method that is responsible for conversion from string to data
      * @param content - contents string
      * @returns - list data formed from contents string
      */
-    import: (content: string, config: ToolConfig<NestedListConfig>) => ListData;
+    import: (content: string, config: ToolConfig<NestedListConfig>) => NestedListData;
   } {
     return {
       export: (data) => {
@@ -123,7 +124,7 @@ export default class NestedList {
   /**
    * Get list style name
    */
-  private get listStyle(): ListDataStyle {
+  private get listStyle(): NestedListDataStyle {
     return this.data.style || this.defaultListStyle;
   }
 
@@ -131,7 +132,7 @@ export default class NestedList {
    * Set list style
    * @param style - new style to set
    */
-  private set listStyle(style: ListDataStyle) {
+  private set listStyle(style: NestedListDataStyle) {
     this.data.style = style;
 
     this.changeTabulatorByStyle();
@@ -169,7 +170,7 @@ export default class NestedList {
   /**
    * Tool's data
    */
-  private data: ListData;
+  private data: NestedListData;
 
   /**
    * Editor block api
@@ -210,7 +211,7 @@ export default class NestedList {
       items: [],
     };
 
-    this.data = Object.keys(data).length ? data : initialData;
+    this.data = Object.keys(data).length ? normalizeData(data) : initialData;
 
     /**
      * Assign default value of the property for the ordered list
@@ -227,7 +228,7 @@ export default class NestedList {
    * @param data - current data of the list
    * @returns - string of the recursively merged contents of the items of the list
    */
-  private static joinRecursive(data: ListData | ListItem): string {
+  private static joinRecursive(data: NestedListData | NestedListItem): string {
     return data.items
       .map(item => `${item.content} ${NestedList.joinRecursive(item)}`)
       .join('');
@@ -247,7 +248,7 @@ export default class NestedList {
    * Function that is responsible for content saving
    * @returns formatted content used in editor
    */
-  public save(): ListData {
+  public save(): NestedListData {
     this.data = this.list!.save();
 
     return this.data;
@@ -257,7 +258,7 @@ export default class NestedList {
    * Function that is responsible for mergind two lists into one
    * @param data - data of the next standing list, that should be merged with current
    */
-  public merge(data: ListData): void {
+  public merge(data: NestedListData): void {
     this.list!.merge(data);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type {
   ToolConfig
 } from '@editorjs/editorjs/types/tools';
 import { IconListBulleted, IconListNumbered, IconChecklist } from '@codexteam/icons';
-import type { NestedListConfig, NestedListData, NestedListDataStyle, NestedListItem, ListData } from './types/ListParams';
+import type { NestedListConfig, ListData, NestedListDataStyle, ListItem, OldListData } from './types/ListParams';
 import ListTabulator from './ListTabulator';
 import { CheckListRenderer, OrderedListRenderer, UnorderedListRenderer } from './ListRenderer';
 import type { ListRenderer } from './types/ListRenderer';
@@ -23,7 +23,7 @@ import normalizeData from './utils/normalizeData';
 /**
  * Constructor Params for Nested List Tool, use to pass initial data and settings
  */
-export type ListParams = BlockToolConstructorOptions<NestedListData | ListData, NestedListConfig>;
+export type ListParams = BlockToolConstructorOptions<ListData | OldListData, NestedListConfig>;
 
 /**
  * Default class of the component used in editor
@@ -93,14 +93,14 @@ export default class NestedList {
      * @param data - current list data
      * @returns - contents string formed from list data
      */
-    export: (data: NestedListData) => string;
+    export: (data: ListData) => string;
 
     /**
      * Method that is responsible for conversion from string to data
      * @param content - contents string
      * @returns - list data formed from contents string
      */
-    import: (content: string, config: ToolConfig<NestedListConfig>) => NestedListData;
+    import: (content: string, config: ToolConfig<NestedListConfig>) => ListData;
   } {
     return {
       export: (data) => {
@@ -170,7 +170,7 @@ export default class NestedList {
   /**
    * Tool's data
    */
-  private data: NestedListData;
+  private data: ListData;
 
   /**
    * Editor block api
@@ -228,7 +228,7 @@ export default class NestedList {
    * @param data - current data of the list
    * @returns - string of the recursively merged contents of the items of the list
    */
-  private static joinRecursive(data: NestedListData | NestedListItem): string {
+  private static joinRecursive(data: ListData | ListItem): string {
     return data.items
       .map(item => `${item.content} ${NestedList.joinRecursive(item)}`)
       .join('');
@@ -248,7 +248,7 @@ export default class NestedList {
    * Function that is responsible for content saving
    * @returns formatted content used in editor
    */
-  public save(): NestedListData {
+  public save(): ListData {
     this.data = this.list!.save();
 
     return this.data;
@@ -258,7 +258,7 @@ export default class NestedList {
    * Function that is responsible for mergind two lists into one
    * @param data - data of the next standing list, that should be merged with current
    */
-  public merge(data: NestedListData): void {
+  public merge(data: ListData): void {
     this.list!.merge(data);
   }
 

--- a/src/styles/list.pcss
+++ b/src/styles/list.pcss
@@ -13,7 +13,7 @@
   --checkbox-background: #fff;
   --color-border: #C9C9C9;
   --color-bg-checked: #369FFF;
-  --line-height: 145%;
+  --line-height: 1.45em;
   --color-bg-checked-hover: #0059AB;
   --color-tick: #fff;
   --size-checkbox: 1.2em;

--- a/src/types/ListParams.ts
+++ b/src/types/ListParams.ts
@@ -4,20 +4,20 @@ import type { OlCounterType } from './OlCounterType';
 /**
  * list style to make list as ordered or unordered
  */
-export type ListDataStyle = 'ordered' | 'unordered' | 'checklist';
+export type NestedListDataStyle = 'ordered' | 'unordered' | 'checklist';
 
 /**
- * Output data
+ * Interface that represents data of the Nested List tool
  */
-export interface ListData {
+export interface NestedListData {
   /**
    * list type 'ordered' or 'unordered' or 'checklist'
    */
-  style: ListDataStyle;
+  style: NestedListDataStyle;
   /**
    * list of first-level elements
    */
-  items: ListItem[];
+  items: NestedListItem[];
   /**
    * Max level of the nesting in list
    * If nesting is not needed, it could be set to 1
@@ -34,9 +34,23 @@ export interface ListData {
 }
 
 /**
+ * Interface that represents data of the List tool
+ */
+export interface ListData {
+  /**
+   * Style of the List tool
+   */
+  style: 'ordered' | 'unordered';
+  /**
+   * Array of items of the List tool
+   */
+  items: string[];
+}
+
+/**
  * List item within the output data
  */
-export interface ListItem {
+export interface NestedListItem {
   /**
    * list item text content
    */
@@ -50,7 +64,7 @@ export interface ListItem {
   /**
    * sublist items
    */
-  items: ListItem[];
+  items: NestedListItem[];
 }
 
 /**
@@ -61,5 +75,5 @@ export interface NestedListConfig {
    * default list style: ordered or unordered
    * default is unordered
    */
-  defaultStyle?: ListDataStyle;
+  defaultStyle?: NestedListDataStyle;
 }

--- a/src/types/ListParams.ts
+++ b/src/types/ListParams.ts
@@ -4,7 +4,7 @@ import type { OlCounterType } from './OlCounterType';
 /**
  * list style to make list as ordered or unordered
  */
-export type NestedListDataStyle = 'ordered' | 'unordered' | 'checklist';
+export type ListDataStyle = 'ordered' | 'unordered' | 'checklist';
 
 /**
  * Interface that represents data of the Nested List tool
@@ -13,7 +13,7 @@ export interface ListData {
   /**
    * list type 'ordered' or 'unordered' or 'checklist'
    */
-  style: NestedListDataStyle;
+  style: ListDataStyle;
   /**
    * list of first-level elements
    */
@@ -75,5 +75,5 @@ export interface NestedListConfig {
    * default list style: ordered or unordered
    * default is unordered
    */
-  defaultStyle?: NestedListDataStyle;
+  defaultStyle?: ListDataStyle;
 }

--- a/src/types/ListParams.ts
+++ b/src/types/ListParams.ts
@@ -9,7 +9,7 @@ export type NestedListDataStyle = 'ordered' | 'unordered' | 'checklist';
 /**
  * Interface that represents data of the Nested List tool
  */
-export interface NestedListData {
+export interface ListData {
   /**
    * list type 'ordered' or 'unordered' or 'checklist'
    */
@@ -17,7 +17,7 @@ export interface NestedListData {
   /**
    * list of first-level elements
    */
-  items: NestedListItem[];
+  items: ListItem[];
   /**
    * Max level of the nesting in list
    * If nesting is not needed, it could be set to 1
@@ -36,7 +36,7 @@ export interface NestedListData {
 /**
  * Interface that represents data of the List tool
  */
-export interface ListData {
+export interface OldListData {
   /**
    * Style of the List tool
    */
@@ -50,7 +50,7 @@ export interface ListData {
 /**
  * List item within the output data
  */
-export interface NestedListItem {
+export interface ListItem {
   /**
    * list item text content
    */
@@ -64,7 +64,7 @@ export interface NestedListItem {
   /**
    * sublist items
    */
-  items: NestedListItem[];
+  items: ListItem[];
 }
 
 /**

--- a/src/utils/normalizeData.ts
+++ b/src/utils/normalizeData.ts
@@ -1,0 +1,36 @@
+import type { ListData, NestedListData, NestedListItem } from '../types/ListParams';
+
+/**
+ * Method that checks if data is related to the List or NestedListTool
+ * @param data - data of the List or NestedListTool
+ * @returns true if data related to the List tool, false if to Nested List tool
+ */
+function instanceOfListData(data: NestedListData | ListData): data is ListData {
+  return (typeof data.items[0] === 'string');
+}
+
+/**
+ * Method that normalizes checks if passed data is related to the List tool and normalizes it
+ * @param data - data to be checked
+ * @returns - normalized data, ready to be used by Nested List tool
+ */
+export default function normalizeData(data: NestedListData | ListData): NestedListData {
+  const normalizedDataItems: NestedListItem[] = [];
+
+  if (instanceOfListData(data)) {
+    data.items.forEach((item) => {
+      normalizedDataItems.push({
+        content: item,
+        meta: {},
+        items: [],
+      });
+    });
+
+    return {
+      style: data.style,
+      items: normalizedDataItems,
+    };
+  } else {
+    return data;
+  }
+};

--- a/src/utils/normalizeData.ts
+++ b/src/utils/normalizeData.ts
@@ -1,11 +1,11 @@
-import type { ListData, NestedListData, NestedListItem } from '../types/ListParams';
+import type { OldListData, ListData, ListItem } from '../types/ListParams';
 
 /**
  * Method that checks if data is related to the List or NestedListTool
  * @param data - data of the List or NestedListTool
  * @returns true if data related to the List tool, false if to Nested List tool
  */
-function instanceOfListData(data: NestedListData | ListData): data is ListData {
+function instanceOfListData(data: ListData | OldListData): data is OldListData {
   return (typeof data.items[0] === 'string');
 }
 
@@ -14,8 +14,8 @@ function instanceOfListData(data: NestedListData | ListData): data is ListData {
  * @param data - data to be checked
  * @returns - normalized data, ready to be used by Nested List tool
  */
-export default function normalizeData(data: NestedListData | ListData): NestedListData {
-  const normalizedDataItems: NestedListItem[] = [];
+export default function normalizeData(data: ListData | OldListData): ListData {
+  const normalizedDataItems: ListItem[] = [];
 
   if (instanceOfListData(data)) {
     data.items.forEach((item) => {

--- a/src/utils/normalizeData.ts
+++ b/src/utils/normalizeData.ts
@@ -10,7 +10,7 @@ function instanceOfListData(data: ListData | OldListData): data is OldListData {
 }
 
 /**
- * Method that normalizes checks if passed data is related to the List tool and normalizes it
+ * Method that checks if passed data is related to the legacy format and normalizes it
  * @param data - data to be checked
  * @returns - normalized data, ready to be used by Nested List tool
  */


### PR DESCRIPTION
## Problem
For now nested list does not support data format of the @editor-js/list tool

## Solution
- Added util method that checks that passed data related to the Lits tool and normalizes it
- Added demo in index, how block with List tool data displayes with Nested List tool
- Added interface that represents List tool data format

## Additional
- Renamed `ListData` -> `NestedListData`
- Renamed `ListItem` -> `NestedListItem`
- list.pcss variable `--line-height` changed from 145% to 1.45em because `padding-top` of the checkbox was calculated based on it (we cannot calculate in pcss based on persents)
related issues 
#87 
#15