### PR TITLE
Chore (keydown): improve behaviour of getOutOfList

### DIFF
--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -479,7 +479,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
          * If current item is first and last item of the list, then empty list should be deleted after deletion of the item
          */
         if (isFirstItem) {
-          console.log('wrong index');
           this.getOutOfList(currentBlockIndex, true);
         } else {
           /**

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -479,12 +479,12 @@ export default class ListTabulator<Renderer extends ListRenderer> {
          * If current item is first and last item of the list, then empty list should be deleted after deletion of the item
          */
         if (isFirstItem) {
-          this.getOutOfList(currentBlockIndex, true);
+          this.covertItemToDefaultBlock(currentBlockIndex, true);
         } else {
           /**
            * If there are other items in the list, just remove current item and get out of the list
            */
-          this.getOutOfList();
+          this.covertItemToDefaultBlock();
         }
 
         return;
@@ -544,7 +544,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       /**
        * If current item is first item of the list, then we need to merge first item content with previous block
        */
-      this.getOutOfListFromFirstItem();
+      this.covertFirstItemToDefaultBlock();
 
       return;
     }
@@ -681,7 +681,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
      * It means, that we would not split on two lists, if one of them would be empty
      */
     if (item.previousElementSibling === null && item.parentNode === this.listWrapper) {
-      this.getOutOfList(currentBlockIndex);
+      this.covertItemToDefaultBlock(currentBlockIndex);
 
       return;
     }
@@ -719,7 +719,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     /**
      * Insert paragraph
      */
-    this.getOutOfList(currentBlockIndex + 1);
+    this.covertItemToDefaultBlock(currentBlockIndex + 1);
 
     /**
      * Remove temporary new list wrapper used for content save
@@ -1043,25 +1043,25 @@ export default class ListTabulator<Renderer extends ListRenderer> {
 
   /**
    * Get out from List Tool by Enter on the empty last item
-   * @param index - optional parameter represents index, where would be inseted default block
-   * @param removeBlock - optional parameter, that represents condition, if List should be removed
+   * @param newBloxkIndex - optional parameter represents index, where would be inseted default block
+   * @param removeList - optional parameter, that represents condition, if List should be removed
    */
-  private getOutOfList(index?: number, removeBlock?: boolean): void {
+  private covertItemToDefaultBlock(newBloxkIndex?: number, removeList?: boolean): void {
     let newBlock;
 
     const currentItem = this.currentItem;
 
     const currentItemContent = currentItem !== null ? this.renderer.getItemContent(currentItem) : '';
 
-    if (removeBlock === true) {
+    if (removeList === true) {
       this.api.blocks.delete();
     }
 
     /**
      * Check that index have passed
      */
-    if (index !== undefined) {
-      newBlock = this.api.blocks.insert(undefined, { text: currentItemContent }, undefined, index);
+    if (newBloxkIndex !== undefined) {
+      newBlock = this.api.blocks.insert(undefined, { text: currentItemContent }, undefined, newBloxkIndex);
     } else {
       newBlock = this.api.blocks.insert();
     }
@@ -1075,7 +1075,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
    * This method could be called when backspace button pressed at start of the first item of the list
    * First item of the list would be converted to the paragraph and first item children would be unshifted
    */
-  private getOutOfListFromFirstItem(): void {
+  private covertFirstItemToDefaultBlock(): void {
     const currentItem = this.currentItem;
 
     if (currentItem === null) {
@@ -1116,7 +1116,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
      */
     const removeBlock = currentItemSiblings === null;
 
-    this.getOutOfList(currentBlockIndex, removeBlock);
+    this.covertItemToDefaultBlock(currentBlockIndex, removeBlock);
   }
 
   /**

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -479,12 +479,12 @@ export default class ListTabulator<Renderer extends ListRenderer> {
          * If current item is first and last item of the list, then empty list should be deleted after deletion of the item
          */
         if (isFirstItem) {
-          this.covertItemToDefaultBlock(currentBlockIndex, true);
+          this.convertItemToDefaultBlock(currentBlockIndex, true);
         } else {
           /**
            * If there are other items in the list, just remove current item and get out of the list
            */
-          this.covertItemToDefaultBlock();
+          this.convertItemToDefaultBlock();
         }
 
         return;
@@ -544,7 +544,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       /**
        * If current item is first item of the list, then we need to merge first item content with previous block
        */
-      this.covertFirstItemToDefaultBlock();
+      this.convertFirstItemToDefaultBlock();
 
       return;
     }
@@ -681,7 +681,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
      * It means, that we would not split on two lists, if one of them would be empty
      */
     if (item.previousElementSibling === null && item.parentNode === this.listWrapper) {
-      this.covertItemToDefaultBlock(currentBlockIndex);
+      this.convertItemToDefaultBlock(currentBlockIndex);
 
       return;
     }
@@ -719,7 +719,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     /**
      * Insert paragraph
      */
-    this.covertItemToDefaultBlock(currentBlockIndex + 1);
+    this.convertItemToDefaultBlock(currentBlockIndex + 1);
 
     /**
      * Remove temporary new list wrapper used for content save
@@ -1042,11 +1042,11 @@ export default class ListTabulator<Renderer extends ListRenderer> {
   }
 
   /**
-   * Get out from List Tool by Enter on the empty last item
+   * Convert current item to default block with passed index
    * @param newBloxkIndex - optional parameter represents index, where would be inseted default block
    * @param removeList - optional parameter, that represents condition, if List should be removed
    */
-  private covertItemToDefaultBlock(newBloxkIndex?: number, removeList?: boolean): void {
+  private convertItemToDefaultBlock(newBloxkIndex?: number, removeList?: boolean): void {
     let newBlock;
 
     const currentItem = this.currentItem;
@@ -1071,11 +1071,11 @@ export default class ListTabulator<Renderer extends ListRenderer> {
   }
 
   /**
-   * Get out of List from first item
+   * Convert first item of the list to default block
    * This method could be called when backspace button pressed at start of the first item of the list
    * First item of the list would be converted to the paragraph and first item children would be unshifted
    */
-  private covertFirstItemToDefaultBlock(): void {
+  private convertFirstItemToDefaultBlock(): void {
     const currentItem = this.currentItem;
 
     if (currentItem === null) {
@@ -1114,9 +1114,9 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     /**
      * If current item has no siblings, than List is empty, and it should be deleted
      */
-    const removeBlock = currentItemSiblings === null;
+    const removeList = currentItemSiblings === null;
 
-    this.covertItemToDefaultBlock(currentBlockIndex, removeBlock);
+    this.convertItemToDefaultBlock(currentBlockIndex, removeList);
   }
 
   /**

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -652,6 +652,13 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     const currentItemChildrenList = getChildItems(item);
 
     /**
+     * Get current list block index
+     */
+    const currentBlock = this.block;
+
+    const currentBlockIndex = this.api.blocks.getCurrentBlockIndex();
+
+    /**
      * First child item should be unshifted because separated list should start
      * with item with first nesting level
      */
@@ -668,11 +675,11 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     }
 
     /**
-     * If item is first item of the list, we should just remove the item
+     * If item is first item of the list, we should just get out of the list
      * It means, that we would not split on two lists, if one of them would be empty
      */
     if (item.previousElementSibling === null && item.parentNode === this.listWrapper) {
-      this.api.blocks.delete();
+      this.getOutOfList(currentBlockIndex);
 
       return;
     }
@@ -701,13 +708,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     const newListContent = this.save(newListWrapper);
 
     newListContent.start = this.data.style == 'ordered' ? 1 : undefined;
-
-    /**
-     * Get current list block index
-     */
-    const currentBlock = this.block;
-
-    const currentBlockIndex = this.api.blocks.getCurrentBlockIndex();
 
     /**
      * Insert separated list with trailing items

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -534,6 +534,11 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     }
 
     /**
+     * Prevent Editor.js backspace handling
+     */
+    event.stopPropagation();
+
+    /**
      * First item of the list should become paragraph on backspace
      */
     if (currentItem.parentNode === this.listWrapper && currentItem.previousElementSibling === null) {
@@ -541,11 +546,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
        * If current item is first item of the list, then we need to merge first item content with previous block
        */
       this.getOutOfListFromFirstItem();
-
-      /**
-       * Prevent Editor.js backspace handling
-       */
-      event.stopPropagation();
 
       return;
     }

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -468,6 +468,8 @@ export default class ListTabulator<Renderer extends ListRenderer> {
     const isFirstLevelItem = currentItem.parentNode === this.listWrapper;
     const isFirstItem = currentItem.previousElementSibling === null;
 
+    const currentBlockIndex = this.api.blocks.getCurrentBlockIndex();
+
     /**
      * On Enter in the last empty item, get out of list
      */
@@ -477,7 +479,8 @@ export default class ListTabulator<Renderer extends ListRenderer> {
          * If current item is first and last item of the list, then empty list should be deleted after deletion of the item
          */
         if (isFirstItem) {
-          this.getOutOfList(undefined, true);
+          console.log('wrong index');
+          this.getOutOfList(currentBlockIndex, true);
         } else {
           /**
            * If there are other items in the list, just remove current item and get out of the list

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -1064,6 +1064,7 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       newBlock = this.api.blocks.insert();
     }
 
+    currentItem?.remove();
     this.api.caret.setToBlock(newBlock, 'start');
   }
 

--- a/src/ListTabulator/index.ts
+++ b/src/ListTabulator/index.ts
@@ -473,8 +473,6 @@ export default class ListTabulator<Renderer extends ListRenderer> {
      */
     if (isFirstLevelItem && isEmpty) {
       if (isLastItem(currentItem) && !itemHasSublist(currentItem)) {
-        console.log('getOut of the list would be called');
-
         /**
          * If current item is first and last item of the list, then empty list should be deleted after deletion of the item
          */
@@ -669,15 +667,11 @@ export default class ListTabulator<Renderer extends ListRenderer> {
       focusItem(item, false);
     }
 
-    console.log('split list', item, item.previousElementSibling, item.parentNode);
-
     /**
      * If item is first item of the list, we should just remove the item
      * It means, that we would not split on two lists, if one of them would be empty
      */
     if (item.previousElementSibling === null && item.parentNode === this.listWrapper) {
-      console.log('remove item');
-
       this.api.blocks.delete();
 
       return;


### PR DESCRIPTION
## Problem
1. After splitting of the list on first item we get two lists. One of them is empty (even no item, so just empty wrapper with paddings is left)
2. After pressing `backspace` at start of the first item, we should convert first item of the list to the paragraph

## Solution
- Added `removeBlock` parameter to the `getOutOfList()` method, that represents condition, when List block should be removed after getting out
- Added `getOutOfListFromFirstItem()` method, that unshifts child items of the first element, and calls `getOutOfList` with right conditions